### PR TITLE
Remove bottle :unneeded as it's deprecated

### DIFF
--- a/Formula/mvnd.rb
+++ b/Formula/mvnd.rb
@@ -16,8 +16,6 @@ class Mvnd < Formula
     url :stable
   end
 
-  bottle :unneeded
-
   depends_on "openjdk" => :recommended
 
   def install


### PR DESCRIPTION
  There's no replacement for it cf. Homebrew/brew#11239